### PR TITLE
Fix some link translations in initial PR's

### DIFF
--- a/content/docs/faq-ajax.md
+++ b/content/docs/faq-ajax.md
@@ -6,15 +6,15 @@ layout: docs
 category: FAQ
 ---
 
-### Como fazer uma requisição AJAX? {#como-fazer-uma-requisicao-ajax}
+### Como fazer uma requisição AJAX? {#how-can-i-make-an-ajax-call}
 
 Você pode usar qualquer biblioteca AJAX que desejar com React. Algumas populares são [Axios](https://github.com/axios/axios), [jQuery AJAX](https://api.jquery.com/jQuery.ajax/), e o nativo do navegador [window.fetch](https://developer.mozilla.org/pt-BR/docs/Web/API/Fetch_API).
 
-### Onde eu devo fazer uma requisição AJAX no ciclo de vida do componente? {#onde-eu-devo-fazer-uma-requisicao-ajax-no-ciclo-de-vida-do-componente}
+### Onde eu devo fazer uma requisição AJAX no ciclo de vida do componente? {#where-in-the-component-lifecycle-should-i-make-an-ajax-call}
 
 Você deve preencher dados com requisições AJAX no método [`componentDidMount`](/docs/react-component.html#mounting) do ciclo de vida. Isto é para que você consiga usar `setState` para atualizar seu componente quando os dados forem recebidos.
 
-### Exemplo: Usando resultados AJAX para definir o estado local {#exemplo-usando-ajax-para-definir-o-estado-local}
+### Exemplo: Usando resultados AJAX para definir o estado local {#example-using-ajax-results-to-set-local-state}
 
 O componente abaixo demonstra como deve fazer uma requisição AJAX no `componentDidMount` para preencher o estado (state) local. 
 

--- a/content/docs/faq-build.md
+++ b/content/docs/faq-build.md
@@ -6,15 +6,15 @@ layout: docs
 category: FAQ
 ---
 
-### Eu preciso usar JSX com React? {#eu-preciso-usar-jsx-com-react}
+### Eu preciso usar JSX com React? {#do-i-need-to-use-jsx-with-react}
 
 Não! Confira ["React Sem JSX"](/docs/react-without-jsx.html) para saber mais.
 
-### Eu preciso usar ES6 (+) com React? {#eu-preciso-usar-es6--com-react}
+### Eu preciso usar ES6 (+) com React? {#do-i-need-to-use-es6--with-react}
 
 Não! Confira ["React Sem ES6"](/docs/react-without-es6.html) para saber mais.
 
-### Como posso escrever comentários em JSX? {#como-posso-escrever-comentarios-em-jsx}
+### Como posso escrever comentários em JSX? {#how-can-i-write-comments-in-jsx}
 
 ```jsx
 <div>

--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -20,7 +20,7 @@ Esse código imprime `[2, 4, 6, 8, 10]` no console.
 
 No React, transformar arrays em listas de [elementos](/docs/rendering-elements.html) é praticamente idêntico a isso.
 
-### Renderizando Múltiplos Componentes {#renderizando-multiplos-componentes}
+### Renderizando Múltiplos Componentes {#rendering-multiple-components}
 
 Você pode criar coleções de elementos e [adicioná-los no JSX](/docs/introducing-jsx.html#embedding-expressions-in-jsx) usando chaves `{}`.
 
@@ -46,7 +46,7 @@ ReactDOM.render(
 
 Esse código mostra uma lista não ordenada de números entre 1 e 5.
 
-### Componente de Lista Básico {#componente-de-lista-basico}
+### Componente de Lista Básico {#basic-list-component}
 
 Geralmente você irá renderizar listas dentro de um [componente](/docs/components-and-props.html).
 
@@ -96,7 +96,7 @@ ReactDOM.render(
 
 [**Experimente no CodePen**](https://codepen.io/gaearon/pen/jrXYRR?editors=0011)
 
-## Chaves {#chaves}
+## Chaves {#keys}
 
 As chaves ajudam o React a identificar quais itens sofreram alterações, foram adicionados ou removidos. As chaves devem ser atribuídas aos elementos dentro do array para dar uma identidade estável aos elementos:
 
@@ -134,7 +134,7 @@ Não recomendamos o uso de índices para chave se a ordem dos itens pode ser alt
 
 Aqui você poderá ver [uma explicação aprofundada sobre o porquê o uso das chaves é necessário](/docs/reconciliation.html#recursing-on-children) caso você esteja interessado em aprender mais sobre isso.
 
-### Extraindo Componentes com Chaves {#extraindo-componentes-com-chaves}
+### Extraindo Componentes com Chaves {#extracting-components-with-keys}
 
 As chaves apenas fazem sentido no contexto do array que está encapsulando os itens.
 
@@ -206,7 +206,7 @@ ReactDOM.render(
 
 Por via de regra, os elementos dentro de uma função `map()` devem especificar chaves.
 
-### Chaves devem ser Únicas apenas entre Elementos Irmãos {#chaves-devem-ser-unicas-apenas-entre-elementos-irmaos}
+### Chaves devem ser Únicas apenas entre Elementos Irmãos {#keys-must-only-be-unique-among-siblings}
 
 Chaves usadas nos arrays devem ser únicas entre seus elementos irmãos. Contudo elas não precisam ser únicas globalmente. Podemos usar as mesmas chaves ao criar dois arrays diferentes:
 
@@ -261,7 +261,7 @@ const content = posts.map((post) =>
 
 No exemplo acima, o componente `Post` pode acessar `props.id`. Mas, não pode acessar `props.key`.
 
-### Incluindo map() no JSX {#incluindo-map-no-jsx}
+### Incluindo map() no JSX {#embedding-map-in-jsx}
 
 Nos exemplos acima declaramos uma variável `listItems` separada e adicionamos ela no JSX:
 

--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -10,7 +10,7 @@ React e [Componentes Web](https://developer.mozilla.org/pt-BR/docs/Web/Web_Compo
 
 A maioria das pessoas que usam o React não usam Componentes Web. Mas, talvez você queira, especialmente se você estiver utilizando componentes de UI de terceiros que foram escritos utilizando Componentes Web.
 
-## Usando Componentes Web no React {#usando-componentes-web-no-react}
+## Usando Componentes Web no React {#using-web-components-in-react}
 
 ```javascript
 class HelloMessage extends React.Component {
@@ -40,7 +40,7 @@ function BrickFlipbox() {
 }
 ```
 
-## Usando React nos seus Componentes Web {#usando-react-nos-seus-componentes-web}
+## Usando React nos seus Componentes Web {#using-react-in-your-web-components}
 
 ```javascript
 class XSearch extends HTMLElement {


### PR DESCRIPTION
As per #42, fixed some links in some of the initial PR's. Daunting task but using IntelliJ VCS history helped a bit. I believe most of the PR's in [the list](https://github.com/reactjs/pt-BR.reactjs.org/pulls?q=is%3Apr+is%3Aclosed) are covered, but may need another look through the list.

Added PR's ID in commit messages to make it easy to identify changes.