### PR TITLE
Restore translated internal links

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -27,7 +27,7 @@ Não será necessário usar alguma ferramenta complicada ou instalar algo -- **p
 
 Opcional: [Faça o download do exemplo completo (2KB zipado)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)
 
-### Passo 1: Adicionar um contêiner DOM ao HTML {#passo-1-adicionar-um-conteiner-dom-ao-html}
+### Passo 1: Adicionar um contêiner DOM ao HTML {#step-1-add-a-dom-container-to-the-html}
 
 Primeiramente, abra a página HTML que você deseja alterar. Adicione uma tag `<div>` vazia para marcar o local onde você deseja exibir algo com o React. Por exemplo:
 
@@ -65,7 +65,7 @@ A seguir, adicione três tags `<script>` em sua página HTML logo antes do fecha
 
 As duas primeiras tags adicionam o React. A terceira irá adicionar o código de seu componente.
 
-### Passo 3: Criar um Componente React {#passo-3-criar-um-componente-react}
+### Passo 3: Criar um Componente React {#step-3-create-a-react-component}
 
 Crie um arquivo chamado `like_button.js` próximo a sua página HTML.
 

--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -140,7 +140,7 @@ class LoggingButton extends React.Component {
 
 O problema com esta sintaxe é que um callback diferente é criado toda vez que o `LoggingButton` é renderizado. Na maioria dos casos, tudo bem. No entanto, se esse callback for passado para componentes inferiores através de props, esses componentes poderão fazer uma renderização extra. Geralmente recomendamos a vinculação no construtor ou a sintaxe dos campos de classe para evitar esse tipo de problema de desempenho.
 
-## Passando Argumentos para Manipuladores de Eventos {#passando-argumentos-para-manipuladores-de-eventos}
+## Passando Argumentos para Manipuladores de Eventos {#passing-arguments-to-event-handlers}
 
 Dentro de uma estrutura de repetição é comum querer passar um parâmetro extra para um manipulador de evento. Por exemplo, se `id` é o ID de identificação da linha, qualquer um dos dois a seguir funcionará:
 


### PR DESCRIPTION
Fecha #42

Executei um script grep+diff nos repositorios EN e BR, e os links restantes que ficaram de ser restaurados (#42) estão neste PR.

![diff links internos](https://user-images.githubusercontent.com/12100397/52541038-515ff480-2d99-11e9-8bde-898c892468ca.jpg)

cc. @cezaraugusto 