### PR TITLE
Add event listener and event handler to glossary

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -51,3 +51,5 @@ Suggestion on words and terms:
 * release
 * subscription
 * subscribe
+* event listener
+* event handler


### PR DESCRIPTION
Adiciona os termos "event handler" e "event listener" para o Glossário.

Verifiquei que no MDN esses termos são traduzidos:

Original | Tradução
---|---
event listener | escutador de eventos
event handler | manipulador de eventos

Fonte: https://developer.mozilla.org/pt-BR/docs/Aprender/JavaScript/Elementos_construtivos/Events

Porém, acho estranho. Não sei se é porque estou acostumado com os termos em inglês.

Gostaria da opinião de mais pessoas.