### PR TITLE
Add string literal to untranslated terms

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -65,6 +65,7 @@ Suggestion on words and terms:
 * ref
 * state
 * string
+* string literal
 * template literal
 * UI
 * log


### PR DESCRIPTION
#99 

https://github.com/reactjs/pt-BR.reactjs.org/pull/105#discussion_r257712245

Adicionar String Literal para os termos não traduzidos, seguindo a mesma lógico do já existente template literal.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
