### PR TITLE
Correção: Remover link de "Comunidade" duplicado na barra de navegação

### DIFF
--- a/src/components/LayoutHeader/Header.js
+++ b/src/components/LayoutHeader/Header.js
@@ -140,11 +140,6 @@ const Header = ({location}: {location: Location}) => (
             title="Blog"
             to="/blog/"
           />
-          <HeaderLink
-            isActive={location.pathname.includes('/community/')}
-            title="Community"
-            to="/community/support.html"
-          />
         </nav>
 
         <DocSearch />


### PR DESCRIPTION
Existem atualmente dois links de "Comunidade" na barra de navegação. Um deles em português e outro em inglês. Essa pull request remove o segundo deles.