### PR TITLE
Translation of Error Handling in React 16

### DIFF
--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -56,9 +56,9 @@ O método `componentDidCatch()` funciona como o block `catch {}` do JavaScript, 
 
 Observe que **limitadores de erros, apenas conseguem capturar erros nos componentes abaixo deles na árvore**. Um limitador de erro não consegue capturar um erro dentro de sí próprio. Se um limitador de erro falhar ao tentar renderizar a mensagem de erro, o erro irá propagar até o limitador de erro máis próximo, localizado acima dele. Este também é de modo similar, a como o block `catch {}` funciona no JavaScript.
 
-## Live Demo {#live-demo}
+## Demonstração Ao Vivo {#live-demo}
 
-Check out [this example of declaring and using an error boundary](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) with [React 16 beta](https://github.com/facebook/react/issues/10294).
+Confira [este exemplo de declaração e uso do limitador de erro](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) com o [React 16 beta](https://github.com/facebook/react/issues/10294).
 
 ## Where to Place Error Boundaries {#where-to-place-error-boundaries}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -7,9 +7,9 @@ Como a versão 16 do React está próxima, nós gostaríamos de anunciar algumas
 
 **A propósito, [nós acabamos de lançar a primeira versão beta do React 16 para você testar!](https://github.com/facebook/react/issues/10294)**
 
-## Behavior in React 15 and Earlier {#behavior-in-react-15-and-earlier}
+## Funcionamento no React 15 e Antecessor {#behavior-in-react-15-and-earlier}
 
-In the past, JavaScript errors inside components used to corrupt React’s internal state and cause it to [emit](https://github.com/facebook/react/issues/4026) [cryptic](https://github.com/facebook/react/issues/6895) [errors](https://github.com/facebook/react/issues/8579) on next renders. These errors were always caused by an earlier error in the application code, but React did not provide a way to handle them gracefully in components, and could not recover from them.
+Anteriormente, os erros JavaScript dentro dos componentes constumanvam corromper o estato interno do React e fazer com que ele [emita](https://github.com/facebook/react/issues/4026) [erros](https://github.com/facebook/react/issues/8579) [difíceis de entender](https://github.com/facebook/react/issues/6895) nos próximos renderizadores. Estes erros foram sempre causados por erros antecessores no código da aplicação, mas o React não providenciava uma forma de manipulá-los de um modo elegante nos componentes, e não poderia se recuperar a partir deles.
 
 ## Introducing Error Boundaries {#introducing-error-boundaries}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -76,17 +76,17 @@ Por exemplo, o Facebook Messenger envolve o conteúdo da barra lateral, o painel
 
 Nós também incentivamos você a usar serviços de relatórios de erros JS (ou construir o seu própiro), de modo que você possa aprender sobre exceções não tratadas conforme elas acontecem em produção e corrigi-las.
 
-## Component Stack Traces {#component-stack-traces}
+## Rastros da Pilha do Componente {#component-stack-traces}
 
-React 16 prints all errors that occurred during rendering to the console in development, even if the application accidentally swallows them. In addition to the error message and the JavaScript stack, it also provides component stack traces. Now you can see where exactly in the component tree the failure has happened:
+O React 16 exibe todos os erros que ocorreram durante a renderização de desenvolvimento no console, mesmo se a aplicação acidentalmente tenha os aceitado. Além da mensagen de erro e da pilha JavaScript, também é fornecido os rastros da pilha do componente. Agora você pode ver exatamente onde na àrvode do componente a falha ocorreu:
 
-<img src="../images/docs/error-boundaries-stack-trace.png" alt="Component stack traces in error message" style="width: 100%;">
+<img src="../images/docs/error-boundaries-stack-trace.png" alt="Rastros da pilha do componente em uma mensagem de erro" style="width: 100%;">
 
-You can also see the filenames and line numbers in the component stack trace. This works by default in [Create React App](https://github.com/facebookincubator/create-react-app) projects:
+Você também consegue ver os nomes dos arquivos e os números das linhas no rastro da pilha do componente. Isto funciona por padrão nos projetos [Create React App](https://github.com/facebookincubator/create-react-app):
 
-<img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" alt="Component stack traces with line numbers in error message" style="width: 100%;">
+<img src="../images/docs/error-boundaries-stack-trace-line-numbers.png" alt="Rastro da pilha do componente com número de linhas em uma mensagem de erro" style="width: 100%;">
 
-If you don’t use Create React App, you can add [this plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manually to your Babel configuration. Note that it’s intended only for development and **must be disabled in production**.
+Se você não usa o Create React App, você pode adicionar [este plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manualmente as configurações do seu Babel. Observe que isto destina-se apenas para desenvolvimento e **deve ser desativado em produção**.
 
 ## Why Not Use `try` / `catch`? {#why-not-use-try--catch}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -88,9 +88,9 @@ Você também consegue ver os nomes dos arquivos e os números das linhas no ras
 
 Se você não usa o Create React App, você pode adicionar [este plugin](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source) manualmente as configurações do seu Babel. Observe que isto destina-se apenas para desenvolvimento e **deve ser desativado em produção**.
 
-## Why Not Use `try` / `catch`? {#why-not-use-try--catch}
+## Por que não usar `try` / `catch`? {#why-not-use-try--catch}
 
-`try` / `catch` is great but it only works for imperative code:
+`try` / `catch` é ótimo, mas funciona apenas para código imperativo:
 
 ```js
 try {
@@ -100,13 +100,13 @@ try {
 }
 ```
 
-However, React components are declarative and specify *what* should be rendered:
+Porém, componentes React são declarativos e especificam *o que* deve ser renderizado:
 
 ```js
 <Button />
 ```
 
-Error boundaries preserve the declarative nature of React, and behave as you would expect. For example, even if an error occurs in a `componentDidUpdate` method caused by a `setState` somewhere deep in the tree, it will still correctly propagate to the closest error boundary.
+Limitadores de erros preservam a natureza declarativa do React, e se comportam como você esperaria. Por exemplo, mesmo se um erro ocorresse no método `componentDidUpdate`, causado por um `setState` em algum lugar profundo da árvore, ainda assim irá propagar corretamente para o limitador de erro mais próximo.
 
 ## Naming Changes from React 15 {#naming-changes-from-react-15}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -64,17 +64,17 @@ Confira [este exemplo de declaração e uso do limitador de erro](https://codepe
 
 Os pequenos detalhes dos limitadores de erros depende de você. Você pode envolver componentes de rota (superior aos outros componentes) para mostrar uma mensagem, como "Algo deu errado" para o usuário, semelhante aos frameworks de lado do servidor, que geralmente lidam com os conflitos. Você também pode envolver widgets individualmente em um limitador de erro, para os proteger de colidirem com o resto da aplicação.
 
-## New Behavior for Uncaught Errors {#new-behavior-for-uncaught-errors}
+## Novo Comportamento para Erros Não Capturados {#new-behavior-for-uncaught-errors}
 
-This change has an important implication. **As of React 16, errors that were not caught by any error boundary will result in unmounting of the whole React component tree.**
+Esta mudança tem uma consequência importante. A partir do React 16, os erros que não forem capturados pelos limitadores de erros, resultará no desmontamento completo da àrvore do componente React. 
 
-We debated this decision, but in our experience it is worse to leave corrupted UI in place than to completely remove it. For example, in a product like Messenger leaving the broken UI visible could lead to somebody sending a message to the wrong person. Similarly, it is worse for a payments app to display a wrong amount than to render nothing.
+Nós discutimos esta decisão, mas pela nossa experiência é pior deixar a UI corrompida ao invés de removê-la completamente. Por exemplo, em um produto como Messenger, deixar uma UI corrompida visível pode levar alguém a enviar uma mensagem para uma pessoa errada. De forma similar, é pior para um app de pagamento mostrar uma quantia errada do que renderizar nada.  
 
-This change means that as you migrate to React 16, you will likely uncover existing crashes in your application that have been unnoticed before. Adding error boundaries lets you provide better user experience when something goes wrong.
+Esta mudança significa que à medida que você migra para o React 16, você provavelmente descobrirá falhas existentes na sua aplicação que não foram percebidas anteriormente. Adicionar limitadores de erros permite você prover uma melhor experiência de usuário, quando algo dá errado.
 
-For example, Facebook Messenger wraps content of the sidebar, the info panel, the conversation log, and the message input into separate error boundaries. If some component in one of these UI areas crashes, the rest of them remain interactive.
+Por exemplo, o Facebook Messenger envolve o conteúdo da barra lateral, o painel de informações, o log de conversação e o campo de entrada da mensagem dentro de limitadores de erros separados. Se algum componente de uma dessas áreas da UI falharem, o resto deles permanecem interativo.
 
-We also encourage you to use JS error reporting services (or build your own) so that you can learn about unhandled exceptions as they happen in production, and fix them.
+Nós também incentivamos você a usar serviços de relatórios de erros JS (ou construir o seu própiro), de modo que você possa aprender sobre exceções não tratadas conforme elas acontecem em produção e corrigi-las.
 
 ## Component Stack Traces {#component-stack-traces}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -9,7 +9,7 @@ Como a versão 16 do React está próxima, nós gostaríamos de anunciar algumas
 
 ## Funcionamento no React 15 e Antecessor {#behavior-in-react-15-and-earlier}
 
-Anteriormente, os erros JavaScript dentro dos componentes constumanvam corromper o estato interno do React e fazer com que ele [emita](https://github.com/facebook/react/issues/4026) [erros](https://github.com/facebook/react/issues/8579) [difíceis de entender](https://github.com/facebook/react/issues/6895) nos próximos renderizadores. Estes erros foram sempre causados por erros antecessores no código da aplicação, mas o React não providenciava uma forma de manipulá-los de um modo elegante nos componentes, e não poderia se recuperar a partir deles.
+Anteriormente, os erros JavaScript dentro dos componentes costumavam corromper o estado interno do React e fazer com que ele [emita](https://github.com/facebook/react/issues/4026) [erros](https://github.com/facebook/react/issues/8579) [difíceis de entender](https://github.com/facebook/react/issues/6895) nos próximos renderizadores. Estes erros foram sempre causados por erros antecessores no código da aplicação, mas o React não providenciava uma forma de manipulá-los de um modo elegante nos componentes, e não poderia se recuperar a partir deles.
 
 ## Introduzindo as Limitações de Erros {#introducing-error-boundaries}
 <!-- ## Introducing Error Boundaries {#introducing-error-boundaries} -->
@@ -54,7 +54,7 @@ Então você pode usar ele como um componente comum:
 
 O método `componentDidCatch()` funciona como o block `catch {}` do JavaScript, porém, para componentes. Apenas componentes de classe podem ser limitadores de erros. Na prática, na maioria das vezes, você vai querer declarar um componente limitador de error apenas uma vez e usá-lo ao longo da sua aplicação. 
 
-Observe que **limitadores de erros, apenas conseguem capturar erros nos componentes abaixo deles na árvore**. Um limitador de erro não consegue capturar um erro dentro de sí próprio. Se um limitador de erro falhar ao tentar renderizar a mensagem de erro, o erro irá propagar até o limitador de erro máis próximo, localizado acima dele. Este também é de modo similar, a como o block `catch {}` funciona no JavaScript.
+Observe que **limitadores de erros, apenas conseguem capturar erros nos componentes abaixo deles na árvore**. Um limitador de erro não consegue capturar um erro dentro de sí próprio. Se um limitador de erro falhar ao tentar renderizar a mensagem de erro, o erro irá propagar até o limitador de erro máis próximo, localizado acima dele. Este também é de modo similar, como o block `catch {}` funciona no JavaScript.
 
 ## Demonstração Ao Vivo {#live-demo}
 
@@ -70,7 +70,7 @@ Esta mudança tem uma consequência importante. A partir do React 16, os erros q
 
 Nós discutimos esta decisão, mas pela nossa experiência é pior deixar a UI corrompida ao invés de removê-la completamente. Por exemplo, em um produto como Messenger, deixar uma UI corrompida visível pode levar alguém a enviar uma mensagem para uma pessoa errada. De forma similar, é pior para um app de pagamento mostrar uma quantia errada do que renderizar nada.  
 
-Esta mudança significa que à medida que você migra para o React 16, você provavelmente descobrirá falhas existentes na sua aplicação que não foram percebidas anteriormente. Adicionar limitadores de erros permite você prover uma melhor experiência de usuário, quando algo dá errado.
+Esta mudança significa que à medida que você migra para o React 16, você provavelmente descobrirá falhas existentes na sua aplicação que não foram percebidas anteriormente. Adicionar limitadores de erros permite você prover uma melhor experiência de usuário quando algo dá errado.
 
 Por exemplo, o Facebook Messenger envolve o conteúdo da barra lateral, o painel de informações, o log de conversação e o campo de entrada da mensagem dentro de limitadores de erros separados. Se algum componente de uma dessas áreas da UI falharem, o resto deles permanecem interativo.
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -1,5 +1,5 @@
 ---
-title: "Tratamento de Error no React 16"
+title: "Tratamento de Erro no React 16"
 author: [gaearon]
 ---
 
@@ -11,13 +11,14 @@ Como a versão 16 do React está próxima, nós gostaríamos de anunciar algumas
 
 Anteriormente, os erros JavaScript dentro dos componentes constumanvam corromper o estato interno do React e fazer com que ele [emita](https://github.com/facebook/react/issues/4026) [erros](https://github.com/facebook/react/issues/8579) [difíceis de entender](https://github.com/facebook/react/issues/6895) nos próximos renderizadores. Estes erros foram sempre causados por erros antecessores no código da aplicação, mas o React não providenciava uma forma de manipulá-los de um modo elegante nos componentes, e não poderia se recuperar a partir deles.
 
-## Introducing Error Boundaries {#introducing-error-boundaries}
+## Introduzindo as Limitações de Erros {#introducing-error-boundaries}
+<!-- ## Introducing Error Boundaries {#introducing-error-boundaries} -->
 
-A JavaScript error in a part of the UI shouldn’t break the whole app. To solve this problem for React users, React 16 introduces a new concept of an “error boundary”.
+Um erro JavaScript na parte da UI não deve parar todo a aplicação. Para resolver estes problemas para os usuário do React, o React 16 introduz um novo conceito de "limitação de erro"  
 
-Error boundaries are React components that **catch JavaScript errors anywhere in their child component tree, log those errors, and display a fallback UI** instead of the component tree that crashed. Error boundaries catch errors during rendering, in lifecycle methods, and in constructors of the whole tree below them.
+Limitações de erros são componentes React, que **capturam os erros JavaScript em qualquer lugar referente à arvore de seus componentes filhos, registra os erros e mostra uma alterantiva de UI** ao invés da árvore do componente que foi danificada. As limitações de erros capturam os erros durante a renderização, nos métodos de ciclo de vida e nos construtores de toda a árvore abaixo dele.
 
-A class component becomes an error boundary if it defines a new lifecycle method called `componentDidCatch(error, info)`:
+Um componente de classe torna-se um limitador de erro, se ele definir um novo método do ciclo de vida, chamado `componentDidCatch(error, info)`:
 
 ```js{7-12,15-18}
 class ErrorBoundary extends React.Component {
@@ -27,23 +28,23 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    // Display fallback UI
+    // Mostra uma UI alternativa
     this.setState({ hasError: true });
-    // You can also log the error to an error reporting service
+    // Você também pode registrar o erro em um serviço de relatório de erros
     logErrorToMyService(error, info);
   }
 
   render() {
     if (this.state.hasError) {
-      // You can render any custom fallback UI
-      return <h1>Something went wrong.</h1>;
+      // Você pode renderizar qualquer alternativa de UI
+      return <h1>Algo deu errado.</h1>;
     }
     return this.props.children;
   }
 }
 ```
 
-Then you can use it as a regular component:
+Então você pode usar ele como um componente comum:
 
 ```js
 <ErrorBoundary>
@@ -51,9 +52,9 @@ Then you can use it as a regular component:
 </ErrorBoundary>
 ```
 
-The `componentDidCatch()` method works like a JavaScript `catch {}` block, but for components. Only class components can be error boundaries. In practice, most of the time you’ll want to declare an error boundary component once and use it throughout your application.
+O método `componentDidCatch()` funciona como o block `catch {}` do JavaScript, porém, para componentes. Apenas componentes de classe podem ser limitadores de erros. Na prática, na maioria das vezes, você vai querer declarar um componente limitador de error apenas uma vez e usá-lo ao longo da sua aplicação. 
 
-Note that **error boundaries only catch errors in the components below them in the tree**. An error boundary can’t catch an error within itself. If an error boundary fails trying to render the error message, the error will propagate to the closest error boundary above it. This, too, is similar to how `catch {}` block works in JavaScript.
+Observe que **limitadores de erros, apenas conseguem capturar erros nos componentes abaixo deles na árvore**. Um limitador de erro não consegue capturar um erro dentro de sí próprio. Se um limitador de erro falhar ao tentar renderizar a mensagem de erro, o erro irá propagar até o limitador de erro máis próximo, localizado acima dele. Este também é de modo similar, a como o block `catch {}` funciona no JavaScript.
 
 ## Live Demo {#live-demo}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -1,11 +1,11 @@
 ---
-title: "Error Handling in React 16"
+title: "Tratamento de Error no React 16"
 author: [gaearon]
 ---
 
-As React 16 release is getting closer, we would like to announce a few changes to how React handles JavaScript errors inside components. These changes are included in React 16 beta versions, and will be a part of React 16.
+Como a versão 16 do React está próxima, nós gostaríamos de anunciar algumas pequenas mudanças de como o React lida com os erros JavaScript dentro dos componentes. Estas mudanças foram incluidas na versão beta do React 16 e fará parte do React 16.  
 
-**By the way, [we just released the first beta of React 16 for you to try!](https://github.com/facebook/react/issues/10294)**
+**A propósito, [nós acabamos de lançar a primeira versão beta do React 16 para você testar!](https://github.com/facebook/react/issues/10294)**
 
 ## Behavior in React 15 and Earlier {#behavior-in-react-15-and-earlier}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -108,8 +108,8 @@ Porém, componentes React são declarativos e especificam *o que* deve ser rende
 
 Limitadores de erros preservam a natureza declarativa do React, e se comportam como você esperaria. Por exemplo, mesmo se um erro ocorresse no método `componentDidUpdate`, causado por um `setState` em algum lugar profundo da árvore, ainda assim irá propagar corretamente para o limitador de erro mais próximo.
 
-## Naming Changes from React 15 {#naming-changes-from-react-15}
+## Mudanças de Nomenclatura do React 15 {#naming-changes-from-react-15}
 
-React 15 included a very limited support for error boundaries under a different method name: `unstable_handleError`. This method no longer works, and you will need to change it to `componentDidCatch` in your code starting from the first 16 beta release.
+O React 15 incluiu um suporte muito restrito aos limitadores de erros utilizando um nome de método diferente: `unstable_handleError`. Este método não funciona mais, e você precisará trocar em seu código para `componentDidCatch` a partir da primeira versão beta 16.  
 
-For this change, we’ve provided [a codemod](https://github.com/reactjs/react-codemod#error-boundaries) to automatically migrate your code.
+Para esta mudança, nós fornecemos [uma ferramenta de refatoração](https://github.com/reactjs/react-codemod#error-boundaries) para migrar seu código automaticamente.

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -60,9 +60,9 @@ Observe que **limitadores de erros, apenas conseguem capturar erros nos componen
 
 Confira [este exemplo de declaração e uso do limitador de erro](https://codepen.io/gaearon/pen/wqvxGa?editors=0010) com o [React 16 beta](https://github.com/facebook/react/issues/10294).
 
-## Where to Place Error Boundaries {#where-to-place-error-boundaries}
+## Onde Posicionar os Limitadores de Erros  {#where-to-place-error-boundaries}
 
-The granularity of error boundaries is up to you. You may wrap top-level route components to display a “Something went wrong” message to the user, just like server-side frameworks often handle crashes. You may also wrap individual widgets in an error boundary to protect them from crashing the rest of the application.
+Os pequenos detalhes dos limitadores de erros depende de você. Você pode envolver componentes de rota (superior aos outros componentes) para mostrar uma mensagem, como "Algo deu errado" para o usuário, semelhante aos frameworks de lado do servidor, que geralmente lidam com os conflitos. Você também pode envolver widgets individualmente em um limitador de erro, para os proteger de colidirem com o resto da aplicação.
 
 ## New Behavior for Uncaught Errors {#new-behavior-for-uncaught-errors}
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -12,7 +12,6 @@ Como a versão 16 do React está próxima, nós gostaríamos de anunciar algumas
 Anteriormente, os erros JavaScript dentro dos componentes costumavam corromper o estado interno do React e fazer com que ele [emita](https://github.com/facebook/react/issues/4026) [erros](https://github.com/facebook/react/issues/8579) [difíceis de entender](https://github.com/facebook/react/issues/6895) nos próximos renderizadores. Estes erros foram sempre causados por erros antecessores no código da aplicação, mas o React não providenciava uma forma de manipulá-los de um modo elegante nos componentes, e não poderia se recuperar a partir deles.
 
 ## Introduzindo as Limitações de Erros {#introducing-error-boundaries}
-<!-- ## Introducing Error Boundaries {#introducing-error-boundaries} -->
 
 Um erro JavaScript na parte da UI não deve parar todo a aplicação. Para resolver estes problemas para os usuário do React, o React 16 introduz um novo conceito de "limitação de erro"  
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -73,7 +73,7 @@ Esta mudança significa que à medida que você migra para o React 16, você pro
 
 Por exemplo, o Facebook Messenger envolve o conteúdo da barra lateral, o painel de informações, o log de conversação e o campo de entrada da mensagem dentro de limitadores de erros separados. Se algum componente de uma dessas áreas da UI falharem, o resto deles permanecem interativo.
 
-Nós também incentivamos você a usar serviços de relatórios de erros JS (ou construir o seu própiro), de modo que você possa aprender sobre exceções não tratadas conforme elas acontecem em produção e corrigi-las.
+Nós também incentivamos você a usar serviços de relatórios de erros JS (ou construir o seu próprio), de modo que você possa aprender sobre exceções não tratadas conforme elas acontecem em produção e corrigi-las.
 
 ## Rastros da Pilha do Componente {#component-stack-traces}
 


### PR DESCRIPTION
# Translation is done :rocket: 
- [x] Introduction
- [x] Behavior in React 15 and Earlier
- [x] Introducing Error Boundaries
- [x] Live Demo
- [x] Where to Place Error Boundaries
- [x] New Behavior for Uncaught Errors
- [x] Component Stack Traces
- [x] Why Not Use try / catch?
- [x] Naming Changes from React 15
