### PR TITLE
Adjusting docs 'Components and Props'

### DIFF
--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -126,7 +126,7 @@ Tipicamente, novos aplicativos React tem um único componente `App` no topo. Con
 
 Não tenha medo de dividir componentes em componentes menores.
 
-Por exemplo, considere esse commponente `Comment`:
+Por exemplo, considere esse componente `Comment`:
 
 ```js
 function Comment(props) {


### PR DESCRIPTION
Taking a read in the documentation, I noticed a simple one. The word `componente` was written` commponente`. [Link to line](https://github.com/reactjs/pt-BR.reactjs.org/edit/master/content/docs/components-and-props.md#l129).