### PR TITLE
Update context.md

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -227,7 +227,7 @@ Geralmente é necessário atualizar o contexto de um componente que está aninha
 
 ### Consumindo vários Contextos {#consuming-multiple-contexts}
 
-Para que o contexto possa continuar renderizando rápidamente, o React precisa manter cada consumidor de contexto separado em um nó da árvore.
+Para que o contexto possa continuar renderizando rapidamente, o React precisa manter cada consumidor de contexto separado em um nó da árvore.
 
 `embed:context/multiple-contexts.js`
 


### PR DESCRIPTION
rapidamente não possui acento agudo na sílaba "ra". Em português há acentuação gráfica apenas nas três últimas sílabas de todas as palavras do nosso idioma, sem exceção.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
