### PR TITLE
Fix translation PT_BR words

### DIFF
--- a/content/docs/hooks-rules.md
+++ b/content/docs/hooks-rules.md
@@ -12,7 +12,7 @@ Hooks são funções JavaScript, mas você precisa seguir duas regras ao utiliz�
 
 ### Use Hooks Apenas no Nível Superior {#only-call-hooks-at-the-top-level}
 
-**Não use Hooks dentro de loops, regras condicionais ou funções aninhadas (funçoes dentro de funções).** Em vez disso, sempre use Hooks no nível superior de sua função React. Seguindo essas regras, você garante que os Hooks serão chamados na mesma ordem a cada vez que o componente renderizar. É isso que permite que o React preserve corretamente o estado dos Hooks quando são usados várias chamadas a `useState` e `useEffect` na mesma função. (Se você ficou curioso, iremos explicar isso melhor [abaixo](#explanation).)
+**Não use Hooks dentro de loops, regras condicionais ou funções aninhadas (funções dentro de funções).** Em vez disso, sempre use Hooks no nível superior de sua função React. Seguindo essas regras, você garante que os Hooks serão chamados na mesma ordem a cada vez que o componente renderizar. É isso que permite que o React preserve corretamente o estado dos Hooks quando são usados várias chamadas a `useState` e `useEffect` na mesma função. (Se você ficou curioso, iremos explicar isso melhor [abaixo](#explanation).)
 
 ### Use Hooks Apenas Dentro de Funções do React {#only-call-hooks-from-react-functions}
 
@@ -49,7 +49,7 @@ npm install eslint-plugin-react-hooks --save-dev
 
 No futuro, temos a intenção de incluir esse plugin por padrão dentro do Create React App e ferramentas similares.
 
-**Você pode pular para próxima página, onde explica melhor como escrever [seus próprios Hooks](/docs/hooks-custom.html) agora.**. Nessa página continuaremos explicando o motivo por trás dessas regras.
+**Você pode pular para próxima página agora, onde explica melhor como escrever [seus próprios Hooks](/docs/hooks-custom.html).** Nessa página continuaremos explicando o motivo por trás dessas regras.
 
 ## Explicação {#explanation}
 
@@ -132,7 +132,7 @@ useEffect(function persistForm() {
 });
 ```
 
-**Note que você não precisa se preocupar com esse problema, se você usar a [regra fornecida no plugin do ESLint](https://www.npmjs.com/package/eslint-plugin-react-hooks)**. Mas agora você também sabe o *porquê* os Hooks funcionam dessa maneira, e quais os problemas que essas regras previnem.
+**Note que você não precisa se preocupar com esse problema, se você usar a [regra fornecida no plugin do ESLint](https://www.npmjs.com/package/eslint-plugin-react-hooks)**. Mas agora você também sabe o *porquê* dos Hooks funcionarem dessa maneira, e quais os problemas que essas regras previnem.
 
 ## Próximos Passos {#next-steps}
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -272,7 +272,7 @@ Damos mais recomendações em separação de variáveis de state independentes [
 
 ## Próximos Passos {#next-steps}
 
-Nesta página aprendemos sobre um dos Hooks fornecido pelo React, chamado `useState`. Também, em algumas vezes, vamos nos referir como o "State do Hook". Ele nos permite adicionar um state local a um componenete de função -- o que fizemos pela primeira vez!
+Nesta página aprendemos sobre um dos Hooks fornecido pelo React, chamado `useState`. Também, em algumas vezes, vamos nos referir como o "State do Hook". Ele nos permite adicionar um state local a um componente de função -- o que fizemos pela primeira vez!
 
 Também aprendemos um pouco mais sobre o que são Hooks. Hooks são funções que permitem que você utilize recursos do React em componentes de função. Seus nomes sempre começam com `use`, e existem mais Hooks que não vimos ainda.
 


### PR DESCRIPTION
Fix word "componente" in page "Usando o State do Hook" (https://pt-br.reactjs.org/docs/hooks-state.html).