### PR TITLE
fix link in reference-glossary file

### DIFF
--- a/content/docs/reference-glossary.md
+++ b/content/docs/reference-glossary.md
@@ -35,7 +35,7 @@ CDN significa Content Delivery Network. As CDNs fornecem conteúdo estático e e
 
 ## JSX {#jsx}
 
-JSX é uma extensão de sintaxe para JavaScript. É semelhante a uma linguagem de template, mas com todo o poder do JavaScript. JSX é compilado para chamadas `React.createElement ()` que retornam objetos JavaScript simples chamados "elementos React". Para ter uma introdução básica ao JSX [consulte os documentos aqui] (/ docs / introduction-jsx.html) e encontre um tutorial mais aprofundado sobre JSX [aqui] (/ docs / jsx-in-depth.html).
+JSX é uma extensão de sintaxe para JavaScript. É semelhante a uma linguagem de template, mas com todo o poder do JavaScript. JSX é compilado para chamadas `React.createElement ()` que retornam objetos JavaScript simples chamados "elementos React". Para ter uma introdução básica ao JSX [consulte os documentos aqui](/docs/introduction-jsx.html) e encontre um tutorial mais aprofundado sobre JSX [aqui](/docs/jsx-in-depth.html).
 
 React DOM usa a convenção de nomenclatura de propriedades camelCase em vez dos nomes de atributos HTML. Por exemplo, `tabindex` torna-se `tabIndex` em JSX. O atributo `class` também é escrito como `className`, já que `class` é uma palavra reservada em JavaScript:
 
@@ -45,7 +45,7 @@ ReactDOM.render(
   <h1 className="hello">Meu nome é {nome}!</h1>,
   document.getElementById('root')
 );
-```  
+```
 
 ## [Elementos](/docs/rendering-elements.html) {#elements}
 
@@ -77,7 +77,7 @@ class BemVindo extends React.Component {
 }
 ```
 
-Componentes podem ser quebrados em peças distintas de funcionalidade e usados em outros componentes. Componentes podem retornar outros componentes, arrays, strings e números. Uma regra de ouro é que se parte da sua UI é usada várias vezes (Botão, Painel, Avatar), ou é complexa suficiente (App, FeedStory, Comment), é uma boa candidata para ser um componente reutilisável. Nomes de componentes devem também sempre começar com letra maiúscula (`<Wrapper/>` **ao invés de** `<wrapper/>`). Veja [esta documentação](/docs/components-and-props.html#rendering-a-component) para mais informações sobre renderização de componentes. 
+Componentes podem ser quebrados em peças distintas de funcionalidade e usados em outros componentes. Componentes podem retornar outros componentes, arrays, strings e números. Uma regra de ouro é que se parte da sua UI é usada várias vezes (Botão, Painel, Avatar), ou é complexa suficiente (App, FeedStory, Comment), é uma boa candidata para ser um componente reutilisável. Nomes de componentes devem também sempre começar com letra maiúscula (`<Wrapper/>` **ao invés de** `<wrapper/>`). Veja [esta documentação](/docs/components-and-props.html#rendering-a-component) para mais informações sobre renderização de componentes.
 
 ### [`props`](/docs/components-and-props.html) {#props}
 


### PR DESCRIPTION
Fix link in reference-glossary file.
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
