### PR TITLE
Fix hooks-reference.md button typo

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -337,7 +337,7 @@ function Counter({initialCount}) {
         Reset
       </button>
       <button onClick={() => dispatch({type: 'decrement'})}>-</button>
-       patch({type: 'increment'})}>+</button>
+      <button onClick={() => dispatch({type: 'increment'})}>+</button>
     </>
   );
 }


### PR DESCRIPTION
I was getting a little bit deeper into hooks, and then I realised that there was a typo here (no button tags were being opened for the + button).



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
