### PR TITLE
fix(content/docs): fixing a little word

### DIFF
--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -128,7 +128,7 @@ const MyComponent = React.memo(function MyComponent(props) {
 
 Se seu componente renderiza o mesmo resultado dados os mesmos props, você pode envolver nele uma chamada para `React.memo` para um aumento no desempenho em alguns casos, através da memoização do resultado. Isto significa que o React vai pular a renderização do componente e reutilizar o último resultado renderizado.
 
-`React.memo` verifica apenas as alterações de prop. Se o seu componetne de função envolvido em `React.memo` tiver um [`useState`](/docs/hooks-state.html) ou [`useContext`](/docs/hooks-reference.html#usecontext) Hook em sua implementação, ele ainda será renderizado quando o estado ou o contexto mudar.
+`React.memo` verifica apenas as alterações de prop. Se o seu componente de função envolvido em `React.memo` tiver um [`useState`](/docs/hooks-state.html) ou [`useContext`](/docs/hooks-reference.html#usecontext) Hook em sua implementação, ele ainda será renderizado quando o estado ou o contexto mudar.
 
 Por padrão, ele irá comparar apenas superficialmente os objetos nos props. Se você quiser controle sob a comparação, você também pode prover uma função customizada de comparação como segundo argumento.
 


### PR DESCRIPTION
Fixing a wrong word **"componetne"** (to "componente") in Reference React docs.