### PR TITLE
fix translated and duplicated content

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1072,11 +1072,7 @@ Vamos fazer um `map` sobre o `history` no método `render` do componente Game:
 
 **[Veja o código completo nessa etapa](https://codepen.io/gaearon/pen/EmmGEa?editors=0010)**
 
-<<<<<<< HEAD
 À medida que iteramos através do array `history`, a variável `step` se refere ao valor do elemento `history` atual, e `move` se refere ao índice do elemento `history` atual. Estamos interessados ​​apenas em `move` aqui, portanto `step` não está sendo atribuído a nada.
-=======
-As we iterate through `history` array, `step` variable refers to the current `history` element value, and `move` refers to the current `history` element index. We are only interested in `move` here, hence `step` is not getting assigned to anything.
->>>>>>> 17ad2cbc71f4c1fcc3f3f9ae528bfd292a9fced7
 
 Para cada jogada no histórico do Jogo da Velha, nós criamos um item de lista `<li>` que contém um botão `<button>`. O botão tem um manipulador `onClick` que chama um método chamado `this.jumpTo()`. Nós ainda não implementamos o método `jumpTo()`. Por agora, nós devemos ver uma lista das jogadas que já ocorreram no jogo e um aviso no console do developer tools que diz: 
 
@@ -1182,12 +1178,8 @@ Em seguida, definiremos o método `jumpTo` no componente Game para atualizar aqu
     // esse método não mudou
   }
 ```
-<<<<<<< HEAD
-Observe no método `jumpTo`, não atualizamos a propriedade de histórico do estado. Isso ocorre porque as atualizações de estado são mescladas ou, em palavras mais simples, o react atualizará apenas as propriedades mencionadas no método `setState`, deixando o estado restante como está. Para mais informações **[veja a documentação](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-are-merged)**
-=======
 
-Notice in `jumpTo` method, we haven't updated `history` property of the state. That is because state updates are merged or in more simple words React will update only the properties mentioned in `setState` method leaving the remaining state as that is. For more info **[see the documentation](/docs/state-and-lifecycle.html#state-updates-are-merged)**.
->>>>>>> 17ad2cbc71f4c1fcc3f3f9ae528bfd292a9fced7
+Observe no método `jumpTo`, não atualizamos a propriedade de histórico do estado. Isso ocorre porque as atualizações de estado são mescladas ou, em palavras mais simples, o react atualizará apenas as propriedades mencionadas no método `setState`, deixando o estado restante como está. Para mais informações **[veja a documentação](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-are-merged)**
 
 Agora faremos algumas modificações no método `handleClick` do componente Game, que é disparado quando você clica em um quadradado do tabuleiro (square).
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -1179,7 +1179,7 @@ Em seguida, definiremos o método `jumpTo` no componente Game para atualizar aqu
   }
 ```
 
-Observe no método `jumpTo`, não atualizamos a propriedade de histórico do estado. Isso ocorre porque as atualizações de estado são mescladas ou, em palavras mais simples, o react atualizará apenas as propriedades mencionadas no método `setState`, deixando o estado restante como está. Para mais informações **[veja a documentação](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-are-merged)**
+Observe no método `jumpTo`, não atualizamos a propriedade de histórico do estado. Isso ocorre porque as atualizações de estado são mescladas ou, em palavras mais simples, o react atualizará apenas as propriedades mencionadas no método `setState`, deixando o estado restante como está. Para mais informações **[veja a documentação](/docs/state-and-lifecycle.html#state-updates-are-merged)**.
 
 Agora faremos algumas modificações no método `handleClick` do componente Game, que é disparado quando você clica em um quadradado do tabuleiro (square).
 


### PR DESCRIPTION
Quando eu estava navegando na [seção de tutorial](https://pt-br.reactjs.org/tutorial/tutorial.html) notei que havia certos trechos duplicados porém em Inglês. Reparei, também, que tinha um conteúdo um "pouco estranho". Este PR corrige o que foi citado.

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
